### PR TITLE
fix: status command showing "no CVMs found"

### DIFF
--- a/examples/mongo-cluster/deploy.js
+++ b/examples/mongo-cluster/deploy.js
@@ -331,7 +331,7 @@ class PhalaDeployer {
 
     for (const config of deploymentConfigs) {
       try {
-        const cliOutput = await cloudCli('cvms', 'get', config.app_id, '--json');
+        const cliOutput = await cloudCli('cvms', 'get', config.vm_uuid, '--json');
         log.debug(`Got output for ${config.name}: ${cliOutput ? cliOutput.substring(0, 100) : 'empty'}`);
 
         if (!cliOutput) {


### PR DESCRIPTION
The refactored status code was incorrectly passing app_id to 'cvms get' command instead of vm_uuid. The 'cvms get' command expects a CVM UUID, not an App ID. This fixes deploy.js to use config.vm_uuid instead of config.app_id.